### PR TITLE
feat(migrate): add --dry-run flag to preview SQL to stdout

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -10,6 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	dryRun bool
+)
+
 var migrateCmd = &cobra.Command{
 	Use:   "migrate <env>",
 	Short: "Generate migration file for target environment",
@@ -29,13 +33,21 @@ var migrateCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("load current snapshot: %w", err)
 		}
-		// For now, show usage message
-		fmt.Println("Migration requires a base snapshot. Use:")
-		fmt.Println("  schema-sync diff <env1> <env2> to compare snapshots")
 
 		// Placeholder: create empty migration if needed
 		gen := migrate.NewGenerator(cfg.Settings.OutputDir)
 		diffResult := &schema.DiffResult{}
+
+		if dryRun {
+			// Write SQL to stdout instead of file
+			sql, err := gen.GenerateMigrationSQL(env, diffResult)
+			if err != nil {
+				return fmt.Errorf("generate migration SQL: %w", err)
+			}
+			fmt.Println(sql)
+			return nil
+		}
+
 		path, err := gen.GenerateMigration(env, diffResult)
 		if err != nil {
 			return fmt.Errorf("generate migration: %w", err)
@@ -46,6 +58,6 @@ var migrateCmd = &cobra.Command{
 	},
 }
 
-func loadPreviousSnapshot(env string) (*schema.Schema, error) {
-	return nil, fmt.Errorf("previous snapshot not available")
+func init() {
+	migrateCmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview migration SQL to stdout instead of writing to file")
 }

--- a/internal/migrate/generator.go
+++ b/internal/migrate/generator.go
@@ -2,6 +2,7 @@ package migrate
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -51,39 +52,65 @@ func (g *Generator) GenerateMigration(env string, diff *schema.DiffResult) (stri
 	return filepath, nil
 }
 
-func (g *Generator) writeUpMigration(f *os.File, diff *schema.DiffResult) {
+// GenerateMigrationSQL returns the migration SQL as a string (for --dry-run)
+func (g *Generator) GenerateMigrationSQL(env string, diff *schema.DiffResult) (string, error) {
+	var sb strings.Builder
+
+	// Write UP migration
+	sb.WriteString("-- +migrate Up\n")
+	sb.WriteString("-- +migrate StatementBegin\n")
+	g.writeUpMigration(&sbWrapper{&sb}, diff)
+	sb.WriteString("-- +migrate StatementEnd\n\n")
+
+	// Write DOWN migration
+	sb.WriteString("-- +migrate Down\n")
+	sb.WriteString("-- +migrate StatementBegin\n")
+	g.writeDownMigration(&sbWrapper{&sb}, diff)
+	sb.WriteString("-- +migrate StatementEnd\n")
+
+	return sb.String(), nil
+}
+
+// sbWrapper adapts strings.Builder to io.StringWriter
+type sbWrapper struct{ sb *strings.Builder }
+
+func (w *sbWrapper) WriteString(s string) (n int, err error) {
+	return w.sb.WriteString(s)
+}
+
+func (g *Generator) writeUpMigration(w io.StringWriter, diff *schema.DiffResult) {
 	// Added tables
 	for _, t := range diff.Added {
-		f.WriteString(g.generateCreateTable(t))
+		w.WriteString(g.generateCreateTable(t))
 	}
 
 	// Modified tables
 	for _, td := range diff.Modified {
-		g.writeTableChangesUp(f, td)
+		g.writeTableChangesUp(w, td)
 	}
 
 	// Removed tables (only in DOWN, not UP)
-	_ = f
+	_ = w
 }
 
-func (g *Generator) writeDownMigration(f *os.File, diff *schema.DiffResult) {
+func (g *Generator) writeDownMigration(w io.StringWriter, diff *schema.DiffResult) {
 	// Removed tables
 	for _, t := range diff.Removed {
-		f.WriteString(fmt.Sprintf("DROP TABLE IF EXISTS %s;\n", t.Name))
+		w.WriteString(fmt.Sprintf("DROP TABLE IF EXISTS %s;\n", t.Name))
 	}
 
 	// Modified tables - rollback in reverse
 	for _, td := range diff.Modified {
-		g.writeTableChangesDown(f, td)
+		g.writeTableChangesDown(w, td)
 	}
 
 	// Added tables - drop them
 	for _, t := range diff.Added {
-		f.WriteString(fmt.Sprintf("DROP TABLE IF EXISTS %s;\n", t.Name))
+		w.WriteString(fmt.Sprintf("DROP TABLE IF EXISTS %s;\n", t.Name))
 	}
 }
 
-func (g *Generator) writeTableChangesUp(f *os.File, td schema.TableDiff) {
+func (g *Generator) writeTableChangesUp(w io.StringWriter, td schema.TableDiff) {
 	// Added columns
 	for _, col := range td.AddedColumns {
 		stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s %s", td.TableName, col.Name, col.Type)
@@ -93,47 +120,47 @@ func (g *Generator) writeTableChangesUp(f *os.File, td schema.TableDiff) {
 		if col.Default != nil {
 			stmt += fmt.Sprintf(" DEFAULT %s", *col.Default)
 		}
-		f.WriteString(stmt + ";\n")
+		w.WriteString(stmt + ";\n")
 	}
 
 	// Modified columns
 	for _, mc := range td.ModifiedColumns {
 		stmt := fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE %s", td.TableName, mc.Name, mc.NewType)
-		f.WriteString(stmt + ";\n")
+		w.WriteString(stmt + ";\n")
 		if mc.OldNull != mc.NewNull {
 			if mc.NewNull {
-				f.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;\n", td.TableName, mc.Name))
+				w.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;\n", td.TableName, mc.Name))
 			} else {
-				f.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;\n", td.TableName, mc.Name))
+				w.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;\n", td.TableName, mc.Name))
 			}
 		}
 	}
 
 	// Added indexes
 	for _, idx := range td.AddedIndexes {
-		f.WriteString(g.generateCreateIndex(td.TableName, idx))
+		w.WriteString(g.generateCreateIndex(td.TableName, idx))
 	}
 
 	// Added foreign keys
 	for _, fk := range td.AddedFKs {
-		f.WriteString(g.generateAddFK(td.TableName, fk))
+		w.WriteString(g.generateAddFK(td.TableName, fk))
 	}
 }
 
-func (g *Generator) writeTableChangesDown(f *os.File, td schema.TableDiff) {
+func (g *Generator) writeTableChangesDown(w io.StringWriter, td schema.TableDiff) {
 	// Drop added foreign keys
 	for _, fk := range td.AddedFKs {
-		f.WriteString(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s;\n", td.TableName, fk.Name))
+		w.WriteString(fmt.Sprintf("ALTER TABLE %s DROP CONSTRAINT IF EXISTS %s;\n", td.TableName, fk.Name))
 	}
 
 	// Drop added indexes
 	for _, idx := range td.AddedIndexes {
-		f.WriteString(fmt.Sprintf("DROP INDEX IF EXISTS %s;\n", idx.Name))
+		w.WriteString(fmt.Sprintf("DROP INDEX IF EXISTS %s;\n", idx.Name))
 	}
 
 	// Drop added columns
 	for _, col := range td.AddedColumns {
-		f.WriteString(fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s;\n", td.TableName, col.Name))
+		w.WriteString(fmt.Sprintf("ALTER TABLE %s DROP COLUMN IF EXISTS %s;\n", td.TableName, col.Name))
 	}
 }
 


### PR DESCRIPTION
Adds --dry-run flag to the migrate command that writes the generated SQL to stdout instead of writing to a file.

Closes #1