### PR TITLE
fix(migrate): wire --from flag to compute actual schema diff

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/fuleinist/schema-sync/internal/config"
+	"github.com/fuleinist/schema-sync/internal/diff"
 	"github.com/fuleinist/schema-sync/internal/migrate"
 	"github.com/fuleinist/schema-sync/internal/schema"
 	"github.com/spf13/cobra"
@@ -12,6 +13,9 @@ import (
 
 // dryRun outputs migration SQL to stdout instead of writing to a file
 var dryRun bool
+
+// fromEnv is the reference environment to compare against
+var fromEnv string
 
 var migrateCmd = &cobra.Command{
 	Use:   "migrate <env>",
@@ -26,15 +30,37 @@ var migrateCmd = &cobra.Command{
 			return fmt.Errorf("load config: %w", err)
 		}
 
-		// TODO: Load previous snapshot for comparison
-		// Get current snapshot
-		_, err = loadSnapshot(dir, cfg.Settings.SnapshotDir, env)
+		// Load target snapshot
+		targetSchema, err := loadSnapshot(dir, cfg.Settings.SnapshotDir, env)
 		if err != nil {
-			return fmt.Errorf("load current snapshot: %w", err)
+			return fmt.Errorf("load target snapshot %s: %w", env, err)
+		}
+
+		// Load reference snapshot
+		refEnv := fromEnv
+		if refEnv == "" {
+			return fmt.Errorf("--from flag is required (e.g., --from dev); compare environments with 'schema-sync diff <env1> <env2>' first")
+		}
+
+		refSchema, err := loadSnapshot(dir, cfg.Settings.SnapshotDir, refEnv)
+		if err != nil {
+			return fmt.Errorf("load reference snapshot %s: %w", refEnv, err)
+		}
+
+		// Compute diff: ref -> target (changes to apply to ref to get target)
+		diffResult := diff.ComputeDiff(refSchema, targetSchema)
+
+		// Check if there are any changes
+		if len(diffResult.Added) == 0 && len(diffResult.Removed) == 0 && len(diffResult.Modified) == 0 {
+			if dryRun {
+				fmt.Println("[DRY-RUN] No schema changes detected.")
+			} else {
+				fmt.Println("No schema changes detected.")
+			}
+			return nil
 		}
 
 		gen := migrate.NewGenerator(cfg.Settings.OutputDir, dryRun)
-		diffResult := &schema.DiffResult{}
 		path, err := gen.GenerateMigration(env, diffResult)
 		if err != nil {
 			return fmt.Errorf("generate migration: %w", err)
@@ -51,8 +77,10 @@ var migrateCmd = &cobra.Command{
 
 func init() {
 	migrateCmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Output migration SQL to stdout instead of writing to file")
+	migrateCmd.Flags().StringVar(&fromEnv, "from", "", "Reference environment snapshot to compare (required)")
 }
 
+// loadPreviousSnapshot is a stub — previous snapshot tracking not yet implemented
 func loadPreviousSnapshot(env string) (*schema.Schema, error) {
 	return nil, fmt.Errorf("previous snapshot not available")
 }


### PR DESCRIPTION
## Problem

The `migrate` command previously passed an empty `DiffResult{}` to the migration generator, producing no SQL. The `--dry-run` flag was wired but useless because there was no diff to preview.

## Solution

- Add required `--from` flag to specify the reference environment snapshot
- Load both reference and target snapshots, then compute the actual diff using `diff.ComputeDiff`
- Add early-exit when no schema changes exist
- `--dry-run` now works correctly for previewing migrations before writing files

## Use case

`schema-sync migrate prod --from staging --dry-run` lets users preview the exact SQL that will be applied, without side-effects — useful for CI previews and manual review.

Closes #1