### PR TITLE
feat: add --prev-env flag to compare environments for migrations

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/fuleinist/schema-sync/internal/config"
+	"github.com/fuleinist/schema-sync/internal/diff"
 	"github.com/fuleinist/schema-sync/internal/migrate"
 	"github.com/fuleinist/schema-sync/internal/schema"
 	"github.com/spf13/cobra"
@@ -12,6 +13,9 @@ import (
 
 // dryRun outputs migration SQL to stdout instead of writing to a file
 var dryRun bool
+
+// prevEnv is the previous environment to compare against when generating migrations
+var prevEnv string
 
 var migrateCmd = &cobra.Command{
 	Use:   "migrate <env>",
@@ -26,15 +30,30 @@ var migrateCmd = &cobra.Command{
 			return fmt.Errorf("load config: %w", err)
 		}
 
-		// TODO: Load previous snapshot for comparison
-		// Get current snapshot
-		_, err = loadSnapshot(dir, cfg.Settings.SnapshotDir, env)
+		// Load current snapshot for target env
+		currentSchema, err := loadSnapshot(dir, cfg.Settings.SnapshotDir, env)
 		if err != nil {
-			return fmt.Errorf("load current snapshot: %w", err)
+			return fmt.Errorf("load current snapshot for %s: %w", env, err)
+		}
+
+		// Determine previous schema for comparison
+		var prevSchema *schema.Schema
+		if prevEnv != "" {
+			prevSchema, err = loadSnapshot(dir, cfg.Settings.SnapshotDir, prevEnv)
+			if err != nil {
+				return fmt.Errorf("load previous snapshot for %s: %w", prevEnv, err)
+			}
 		}
 
 		gen := migrate.NewGenerator(cfg.Settings.OutputDir, dryRun)
-		diffResult := &schema.DiffResult{}
+
+		var diffResult *schema.DiffResult
+		if prevSchema != nil {
+			diffResult = diff.ComputeDiff(prevSchema, currentSchema)
+		} else {
+			diffResult = &schema.DiffResult{}
+		}
+
 		path, err := gen.GenerateMigration(env, diffResult)
 		if err != nil {
 			return fmt.Errorf("generate migration: %w", err)
@@ -51,6 +70,7 @@ var migrateCmd = &cobra.Command{
 
 func init() {
 	migrateCmd.Flags().BoolVarP(&dryRun, "dry-run", "n", false, "Output migration SQL to stdout instead of writing to file")
+	migrateCmd.Flags().StringVar(&prevEnv, "prev-env", "", "Previous environment to compare against (e.g. --prev-env=dev to diff dev->prod)")
 }
 
 func loadPreviousSnapshot(env string) (*schema.Schema, error) {


### PR DESCRIPTION
## Problem

The `migrate` command generates empty migrations because the TODO comment in the code shows it was never connected to a real diff engine. The `diff` command works fine, but `migrate` had no previous schema to compare against.

## Solution

Add `--prev-env` flag to the `migrate` command so users can specify which environment to diff against. This wires up the existing `diff.ComputeDiff()` function.

Example: `schema-sync migrate prod --prev-env=staging` diffs staging->prod and generates the actual migration SQL for prod changes.

## Use case

A developer snapshots their dev and staging environments, then makes schema changes in prod. Running `schema-sync migrate prod --prev-env=staging` generates the migration showing exactly what changed.