### PR TITLE
fix(cmd): join dir with snapshotDir when reading snapshots

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/fuleinist/schema-sync/internal/config"
 	"github.com/fuleinist/schema-sync/internal/diff"
@@ -44,7 +45,12 @@ var diffCmd = &cobra.Command{
 }
 
 func loadSnapshot(dir, snapshotDir, env string) (*schema.Schema, error) {
-	snapshotFile := snapshotDir + "/" + env + ".json"
+	// `dir` is the project root (typically `os.Getwd()`). The snapshot
+	// writer in `cmd/snapshot.go` writes to `filepath.Join(dir, snapshotDir, ...)`,
+	// so the reader must join the same way; using a bare relative path
+	// (`snapshotDir + "/" + env + ".json"`) only works by accident when
+	// the caller's CWD happens to equal `dir`.
+	snapshotFile := filepath.Join(dir, snapshotDir, env+".json")
 	data, err := os.ReadFile(snapshotFile)
 	if err != nil {
 		return nil, fmt.Errorf("read snapshot %s: %w", env, err)

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fuleinist/schema-sync/internal/schema"
+)
+
+// writeSnapshot writes a minimal valid schema JSON file at
+// <dir>/<snapshotDir>/<env>.json so the test can assert that
+// loadSnapshot joins `dir` with `snapshotDir` before reading.
+func writeSnapshot(t *testing.T, dir, snapshotDir, env string) string {
+	t.Helper()
+	full := filepath.Join(dir, snapshotDir)
+	if err := os.MkdirAll(full, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", full, err)
+	}
+	path := filepath.Join(full, env+".json")
+	payload, err := json.Marshal(&schema.Schema{
+		Tables: []schema.Table{
+			{Name: "users", Columns: []schema.Column{
+				{Name: "id", Type: "INTEGER", Nullable: false, Primary: true},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestLoadSnapshot_JoinsDirWithSnapshotDir pins down the contract that
+// `loadSnapshot` must resolve the snapshot file under `dir`, not as a
+// bare relative path. The previous implementation did
+// `snapshotDir + "/" + env + ".json"` and never used `dir`, so callers
+// that ran from a directory other than the project root got
+// "file not found" even when the snapshot was on disk. The companion
+// writer in `cmd/snapshot.go` correctly does
+// `filepath.Join(dir, cfg.Settings.SnapshotDir, ...)`; this test makes
+// the reader match.
+func TestLoadSnapshot_JoinsDirWithSnapshotDir(t *testing.T) {
+	dir := t.TempDir()
+	snapshotDir := ".schema-sync/snapshots"
+	env := "dev"
+
+	writeSnapshot(t, dir, snapshotDir, env)
+
+	got, err := loadSnapshot(dir, snapshotDir, env)
+	if err != nil {
+		t.Fatalf("loadSnapshot: %v", err)
+	}
+	if len(got.Tables) != 1 || got.Tables[0].Name != "users" {
+		t.Fatalf("expected one table named 'users', got: %+v", got.Tables)
+	}
+}
+
+// TestLoadSnapshot_MissingFileReturnsError covers the negative case:
+// when the snapshot really isn't on disk, the error must point at the
+// env name (so users can tell which env is missing) — not at the joined
+// path (which would leak the absolute CWD into the error).
+func TestLoadSnapshot_MissingFileReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := loadSnapshot(dir, ".schema-sync/snapshots", "missing"); err == nil {
+		t.Fatal("expected error for missing snapshot, got nil")
+	}
+}


### PR DESCRIPTION
## What

`loadSnapshot` in `cmd/diff.go` accepted a `dir` argument but read
the snapshot file with a bare relative path
(`snapshotDir + "/" + env + ".json"`). The companion writer in
`cmd/snapshot.go` correctly uses
`filepath.Join(dir, cfg.Settings.SnapshotDir, ...)`, so the reader
must join the same way.

In the default workflow (run everything from the project root) the two
paths happen to resolve to the same place, so the bug is latent. It
surfaces as soon as the caller's CWD is not equal to `dir` — for
example when `snapshot_dir` is set to an absolute path in
`config.yaml`, or when the binary is invoked from another directory.

## Why

Two things are wrong with the current code:

1. The function signature is a lie: `dir` is a required parameter but
   it does nothing. Future callers will reasonably assume it does.
2. `snapshot` and `diff`/`migrate` resolve the snapshot directory
   differently, even though they live in the same package. The fix
   makes the reader match the writer.

## Testing

Two tests in `cmd/diff_test.go`:

- `TestLoadSnapshot_JoinsDirWithSnapshotDir` writes a real JSON
  snapshot under `t.TempDir()/<snapshotDir>/<env>.json` and asserts
  `loadSnapshot` finds it. The test fails on the old relative-path
  code with `open .schema-sync/snapshots/dev.json: no such file or
  directory`.
- `TestLoadSnapshot_MissingFileReturnsError` covers the negative case
  so the error path stays exercised.

`go test ./...` passes; `go vet ./...` is clean.