### PR TITLE
fix(diff): show nullability and default changes in printDiff

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -95,8 +95,31 @@ func printDiff(result *schema.DiffResult) {
 				fmt.Printf("      - column: %s %s\n", c.Name, c.Type)
 			}
 			for _, mc := range td.ModifiedColumns {
-				fmt.Printf("      ~ column: %s %s -> %s\n", mc.Name, mc.OldType, mc.NewType)
+				// compareTables records a modified column whenever Type,
+				// Nullable, or Default changes; the display must reflect
+				// every change so users see the full diff (e.g. a
+				// nullability flip from NOT NULL to NULL was previously
+				// hidden behind an unchanged Type string).
+				typeChanged := mc.OldType != mc.NewType
+				if typeChanged {
+					fmt.Printf("      ~ column: %s %s -> %s\n", mc.Name, mc.OldType, mc.NewType)
+				} else {
+					fmt.Printf("      ~ column: %s\n", mc.Name)
+				}
+				if mc.OldNull != mc.NewNull {
+					fmt.Printf("          nullable: %t -> %t\n", mc.OldNull, mc.NewNull)
+				}
+				if !diff.EqualDefault(mc.OldDefault, mc.NewDefault) {
+					fmt.Printf("          default: %s -> %s\n", formatDefault(mc.OldDefault), formatDefault(mc.NewDefault))
+				}
 			}
 		}
 	}
+}
+
+func formatDefault(d *string) string {
+	if d == nil {
+		return "NULL"
+	}
+	return *d
 }

--- a/cmd/diff_test.go
+++ b/cmd/diff_test.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/fuleinist/schema-sync/internal/schema"
@@ -70,3 +72,168 @@ func TestLoadSnapshot_MissingFileReturnsError(t *testing.T) {
 		t.Fatal("expected error for missing snapshot, got nil")
 	}
 }
+
+// captureStdout runs fn and returns whatever it wrote to os.Stdout.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	defer func() { os.Stdout = orig }()
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+	w.Close()
+	return <-done
+}
+
+// TestPrintDiff_ShowsNullableChange is the regression test for the
+// `printDiff` bug: a column whose nullability flips was previously
+// rendered as `~ column: name <type> -> <type>` (no visible change)
+// because the display only ever printed the type. The diff engine
+// correctly detected the change, but the user saw nothing. This test
+// fails on the buggy code and passes once printDiff emits the
+// `nullable: ...` line.
+func TestPrintDiff_ShowsNullableChange(t *testing.T) {
+	defaultVal := "0"
+	result := &schema.DiffResult{
+		Modified: []schema.TableDiff{
+			{
+				TableName: "users",
+				ModifiedColumns: []schema.ColumnChange{
+					{
+						Name:    "email",
+						OldType: "VARCHAR(255)",
+						NewType: "VARCHAR(255)",
+						OldNull: false,
+						NewNull: true,
+						OldDefault: &defaultVal,
+						NewDefault: &defaultVal,
+					},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { printDiff(result) })
+
+	if !strings.Contains(out, "nullable: false -> true") {
+		t.Errorf("expected nullability change to be displayed; got:\n%s", out)
+	}
+	// Bug: the old code printed "~ column: email VARCHAR(255) -> VARCHAR(255)"
+	// with no visible diff. After the fix, when the type is unchanged the
+	// header should be the bare column name.
+	if strings.Contains(out, "VARCHAR(255) -> VARCHAR(255)") {
+		t.Errorf("unchanged type should not be rendered as '-> ' transition; got:\n%s", out)
+	}
+}
+
+// TestPrintDiff_ShowsDefaultChange covers the parallel bug for column
+// default values. The diff engine records the change in `ColumnChange`
+// but the old `printDiff` never rendered it, so a default change was
+// invisible. The fix adds a `default: <old> -> <new>` line.
+func TestPrintDiff_ShowsDefaultChange(t *testing.T) {
+	oldVal := "active"
+	newVal := "inactive"
+	result := &schema.DiffResult{
+		Modified: []schema.TableDiff{
+			{
+				TableName: "users",
+				ModifiedColumns: []schema.ColumnChange{
+					{
+						Name:    "status",
+						OldType: "VARCHAR(20)",
+						NewType: "VARCHAR(20)",
+						OldNull: true,
+						NewNull: true,
+						OldDefault: &oldVal,
+						NewDefault: &newVal,
+					},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { printDiff(result) })
+
+	if !strings.Contains(out, "default: active -> inactive") {
+		t.Errorf("expected default change to be displayed; got:\n%s", out)
+	}
+}
+
+// TestPrintDiff_ShowsTypeChange preserves the existing visible behavior
+// when only the type changes: the original
+// `~ column: name oldType -> newType` line must still appear.
+func TestPrintDiff_ShowsTypeChange(t *testing.T) {
+	result := &schema.DiffResult{
+		Modified: []schema.TableDiff{
+			{
+				TableName: "users",
+				ModifiedColumns: []schema.ColumnChange{
+					{
+						Name:    "age",
+						OldType: "INTEGER",
+						NewType: "BIGINT",
+						OldNull: true,
+						NewNull: true,
+					},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { printDiff(result) })
+
+	if !strings.Contains(out, "~ column: age INTEGER -> BIGINT") {
+		t.Errorf("expected type transition line; got:\n%s", out)
+	}
+}
+
+// TestPrintDiff_ShowsAllThreeKinds exercises the full combination: a
+// single modified column where type, nullability, and default all
+// change at once. All three lines must appear so the user sees the
+// complete diff.
+func TestPrintDiff_ShowsAllThreeKinds(t *testing.T) {
+	oldDefault := "0"
+	newDefault := "1"
+	result := &schema.DiffResult{
+		Modified: []schema.TableDiff{
+			{
+				TableName: "users",
+				ModifiedColumns: []schema.ColumnChange{
+					{
+						Name:    "score",
+						OldType: "INTEGER",
+						NewType: "BIGINT",
+						OldNull: false,
+						NewNull: true,
+						OldDefault: &oldDefault,
+						NewDefault: &newDefault,
+					},
+				},
+			},
+		},
+	}
+
+	out := captureStdout(t, func() { printDiff(result) })
+
+	for _, want := range []string{
+		"~ column: score INTEGER -> BIGINT",
+		"nullable: false -> true",
+		"default: 0 -> 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing line %q in output:\n%s", want, out)
+		}
+	}
+}
+
+

--- a/internal/diff/diff.go
+++ b/internal/diff/diff.go
@@ -83,7 +83,7 @@ func compareTables(oldTable, newTable schema.Table) schema.TableDiff {
 	for name, newCol := range newCols {
 		if oldCol, exists := oldCols[name]; exists {
 			if oldCol.Type != newCol.Type || oldCol.Nullable != newCol.Nullable ||
-				!equalDefault(oldCol.Default, newCol.Default) {
+				!EqualDefault(oldCol.Default, newCol.Default) {
 				td.ModifiedColumns = append(td.ModifiedColumns, schema.ColumnChange{
 					Name:      name,
 					OldType:   oldCol.Type,
@@ -136,7 +136,9 @@ func compareFKs(oldFKs, newFKs []schema.ForeignKey) []schema.ForeignKey {
 	return added
 }
 
-func equalDefault(a, b *string) bool {
+// EqualDefault reports whether two *string column default values are
+// equal. Two nil defaults are equal; one nil and one non-nil are not.
+func EqualDefault(a, b *string) bool {
 	if a == nil && b == nil {
 		return true
 	}


### PR DESCRIPTION
## What

`schema-sync diff` displays column changes that the diff engine detects, but `printDiff` in `cmd/diff.go` only ever printed the type transition. The diff engine in `internal/diff` records a modified column whenever **Type**, **Nullable**, or **Default** changes (see `compareTables` at `internal/diff/diff.go:81`, which inspects all three fields and stores the full state in `ColumnChange`). When only nullability or default flipped, the display rendered the unchanged type and produced a misleading `~ column: name VARCHAR(255) -> VARCHAR(255)` line that hid the real change.

## Why

A user running `schema-sync diff dev prod` to review a column that went from `NOT NULL` to `NULL` (or whose default value changed) saw an empty diff for that column. The change was correctly detected, never displayed.

## Changes

- `cmd/diff.go`: emit `nullable: ...` and `default: ...` lines for modified columns, and only print the type arrow when the type actually changes.
- `internal/diff/diff.go`: promote the package-private `equalDefault` helper to exported `EqualDefault` so `cmd` can reuse it. No change to the diff engine's detection logic.
- `cmd/diff_test.go`: 4 new tests covering nullability-only, default-only, type-only, and combined changes.

## Testing

```
go test ./...
ok  	github.com/fuleinist/schema-sync/cmd	0.008s
ok  	github.com/fuleinist/schema-sync/internal/diff	0.004s
ok  	github.com/fuleinist/schema-sync/internal/migrate	(cached)
```

All 6 tests pass (2 pre-existing `loadSnapshot` tests + 4 new `printDiff` tests).