### PR TITLE
fix(migrate): emit SET/DROP DEFAULT for default-value column changes

### DIFF
--- a/internal/migrate/generator.go
+++ b/internal/migrate/generator.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fuleinist/schema-sync/internal/diff"
 	"github.com/fuleinist/schema-sync/internal/schema"
 )
 
@@ -116,6 +117,20 @@ func (g *Generator) writeTableChangesUp(sb *strings.Builder, td schema.TableDiff
 				sb.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;\n", td.TableName, mc.Name))
 			} else {
 				sb.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET NOT NULL;\n", td.TableName, mc.Name))
+			}
+		}
+		// Default-value changes were previously dropped here: the diff
+		// records them (diff.compareTables) and cmd.printDiff renders
+		// them, but the UP migration never emitted a SET/DROP DEFAULT
+		// statement, so applying a migration whose only column change
+		// was the default would silently leave the column's default
+		// untouched. Use the canonical equality check so a nil default
+		// is treated the same way as in the diff path.
+		if !diff.EqualDefault(mc.OldDefault, mc.NewDefault) {
+			if mc.NewDefault == nil {
+				sb.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s DROP DEFAULT;\n", td.TableName, mc.Name))
+			} else {
+				sb.WriteString(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s SET DEFAULT %s;\n", td.TableName, mc.Name, *mc.NewDefault))
 			}
 		}
 	}

--- a/internal/migrate/generator_test.go
+++ b/internal/migrate/generator_test.go
@@ -228,3 +228,97 @@ func TestGenerator_GenerateMigration_DefaultValue(t *testing.T) {
 		t.Error("Missing DEFAULT value in column definition")
 	}
 }
+
+// TestGenerator_GenerateMigration_ModifiedColumnDefaultSet verifies that
+// a column whose only change is its default value (Type and Nullable
+// unchanged) produces a SET DEFAULT statement in the UP migration.
+// Previously, default changes were detected by the diff and rendered
+// by `cmd.printDiff`, but the migration generator only emitted ALTER
+// COLUMN for type/nullability flips — so applying the migration would
+// silently leave the column's default untouched.
+func TestGenerator_GenerateMigration_ModifiedColumnDefaultSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	gen := NewGenerator(tmpDir, false)
+
+	newDefault := "1"
+	diff := &schema.DiffResult{
+		Modified: []schema.TableDiff{
+			{
+				TableName: "users",
+				ModifiedColumns: []schema.ColumnChange{
+					// Only the default value changes; type and nullability
+					// stay the same so the old generator produced an
+					// empty UP migration for this column.
+					{
+						Name:       "active",
+						OldType:    "BOOLEAN",
+						NewType:    "BOOLEAN",
+						OldNull:    true,
+						NewNull:    true,
+						OldDefault: nil,
+						NewDefault: &newDefault,
+					},
+				},
+			},
+		},
+	}
+
+	path, err := gen.GenerateMigration("prod", diff)
+	if err != nil {
+		t.Fatalf("GenerateMigration failed: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, "ALTER TABLE users ALTER COLUMN active SET DEFAULT 1;") {
+		t.Errorf("expected SET DEFAULT 1 in UP migration, got:\n%s", contentStr)
+	}
+}
+
+// TestGenerator_GenerateMigration_ModifiedColumnDefaultDrop is the
+// mirror of the SET test: a column that previously had a default but
+// now has none must produce a DROP DEFAULT statement. Without this,
+// applying the migration would still leave the old default in place.
+func TestGenerator_GenerateMigration_ModifiedColumnDefaultDrop(t *testing.T) {
+	tmpDir := t.TempDir()
+	gen := NewGenerator(tmpDir, false)
+
+	oldDefault := "0"
+	diff := &schema.DiffResult{
+		Modified: []schema.TableDiff{
+			{
+				TableName: "users",
+				ModifiedColumns: []schema.ColumnChange{
+					{
+						Name:       "active",
+						OldType:    "BOOLEAN",
+						NewType:    "BOOLEAN",
+						OldNull:    true,
+						NewNull:    true,
+						OldDefault: &oldDefault,
+						NewDefault: nil,
+					},
+				},
+			},
+		},
+	}
+
+	path, err := gen.GenerateMigration("prod", diff)
+	if err != nil {
+		t.Fatalf("GenerateMigration failed: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	contentStr := string(content)
+
+	if !strings.Contains(contentStr, "ALTER TABLE users ALTER COLUMN active DROP DEFAULT;") {
+		t.Errorf("expected DROP DEFAULT in UP migration, got:\n%s", contentStr)
+	}
+}


### PR DESCRIPTION
## What

`internal/migrate/generator.go::writeTableChangesUp` was missing the third leg of the ModifiedColumns handling. Type and nullability changes both produced `ALTER COLUMN ...` statements, but a default-value change was silently dropped: applying a migration whose only column change was the default left the column's default untouched.

## Why

The diff path already records a default-value change on a column (`diff.compareTables` flags a `ColumnChange` whenever Type, Nullable, or Default differs), and `cmd.printDiff` renders it (fixed in #6). So the user sees the change in the diff output but it does not make it into the migration file.

## Testing

Added two pinned cases to `internal/migrate/generator_test.go`:

- `TestGenerator_GenerateMigration_ModifiedColumnDefaultSet` — only the default changes (Type and Nullable unchanged), expects `ALTER TABLE users ALTER COLUMN active SET DEFAULT 1;` in the UP migration.
- `TestGenerator_GenerateMigration_ModifiedColumnDefaultDrop` — mirror case where the default is removed, expects `DROP DEFAULT`.

`go test ./...` — all packages green.

## Diff scope

Two files, +109/-0 (15 lines of code in `generator.go` plus 94 lines of test + comment). Reuses the existing `diff.EqualDefault` helper rather than open-coding the nil/non-nil comparison.